### PR TITLE
only run in _site/

### DIFF
--- a/lib/jekyll/webpack.rb
+++ b/lib/jekyll/webpack.rb
@@ -10,7 +10,11 @@ module Jekyll
 
     def self.build(site)
       site_dest = site.dest
-
+      # only run webpack once in _site/, not in subdirectories
+      if not site_dest.end_with?("_site")                                                                                                                                                             
+        return                                                                                                                                                                                
+      end
+      
       stdout, stderr, status = Open3.capture3(
         "../node_modules/.bin/webpack",
         chdir: File.expand_path(site_dest)


### PR DESCRIPTION
This should prevent webpack being run in subdirectories of _site/ and should solve issue #3 where 3rd party plugins run the post_write hook multiple times for different directories.

It works for me™ at the moment and probably shouldn't be merged without changes.

(I don't know anything about jekyll plugin development but I guess the "_site" shouldn't be hardcoded.)