### PR TITLE
Allow plugin to be used with Ruby 3

### DIFF
--- a/lib/jekyll/webpack.rb
+++ b/lib/jekyll/webpack.rb
@@ -55,7 +55,7 @@ module Jekyll
         array_or_scalar(cleanup_files) do |dest_for_clean|
           path = File.expand_path(dest_for_clean, site.dest)
 
-          if File.exists?(path) || Dir.exists?(path)
+          if File.exist?(path) || Dir.exist?(path)
             FileUtils.rm_rf(path)
           end
         end

--- a/lib/jekyll/webpack/version.rb
+++ b/lib/jekyll/webpack/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Webpack
-    VERSION = "0.2.6"
+    VERSION = "0.2.7"
   end
 end


### PR DESCRIPTION
```File.exists?``` no longer exists in Ruby 3 and has been deprecated in favour of ```File.exist?```
```File.exist?``` has been available since before Ruby 2.3.0, which is your minimum required version, so nothing will break with this change